### PR TITLE
Fix Travis NPM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,8 @@ jobs:
 
       before_install: cd frontend
 
+      install:
+        - npm install
+
       script:
-        - npm test
+        - npm run build

--- a/frontend/src/Table.js
+++ b/frontend/src/Table.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 
 const TableHeader = () => {
    return (

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import './index.css'


### PR DESCRIPTION
NPM builds now only run `npm install` and `npm run build` instead of `npm test`. In addition, had to remove some unused dependencies to get the builds to pass.

Closes #24